### PR TITLE
fixed null reference error at onDoubleTapEvent

### DIFF
--- a/android/src/main/java/com/rnmaps/maps/MapView.java
+++ b/android/src/main/java/com/rnmaps/maps/MapView.java
@@ -206,8 +206,11 @@ public class MapView extends com.google.android.gms.maps.MapView implements Goog
 
           @Override
           public boolean onDoubleTapEvent(MotionEvent e){
-            map.animateCamera(CameraUpdateFactory.zoomIn(), 400, null);
-            return true;
+            if(map != null){
+              map.animateCamera(CameraUpdateFactory.zoomIn(), 400, null);
+              return true;
+            }
+            return false;
           }
         });
 


### PR DESCRIPTION
fixed crash - 

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.gms.maps.GoogleMap.animateCamera(com.google.android.gms.maps.CameraUpdate, int, com.google.android.gms.maps.GoogleMap$CancelableCallback)' on a null object reference
       at com.rnmaps.maps.MapView$1.onDoubleTapEvent(MapView.java:209)
```